### PR TITLE
React 16 + using react DOM to render string

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ npm i hapijs-react-views react -S
 
 ```js
 // app.js
-var hapi = require('hapi');
+const hapi = require('hapi');
 server = new hapi.Server();
-var engine = require('hapijs-react-views')();
+const engine = require('hapijs-react-views')();
 
 server.views({
     defaultExtension: 'jsx',
@@ -47,7 +47,7 @@ option | values | default
 The defaults are sane, but just in case you want to change something, here's how it would look:
 
 ```js
-var options = { jsx: { harmony: true } };
+const options = { jsx: { harmony: true } };
 server.views({
     defaultExtension: 'jsx',
     engines: {
@@ -63,11 +63,13 @@ server.views({
 Your views should be node modules that export a React component. Let's assume you have this file in `views/index.jsx`:
 
 ```js
-var HelloMessage = React.createClass({
-  render: function() {
+const React = require('react');
+
+class HelloMessage extends React.Component {
+  render() {
     return <div>Hello {this.props.name}</div>;
   }
-});
+}
 
 module.exports = HelloMessage;
 ```
@@ -103,8 +105,10 @@ Simply pass the relevant props to a layout component.
 
 `views/layouts/default.jsx`:
 ```js
-var DefaultLayout = React.createClass({
-  render: function() {
+const React = require('react');
+
+class DefaultLayout extends React.Component {
+  render() {
     return (
       <html>
         <head><title>{this.props.title}</title></head>
@@ -112,24 +116,25 @@ var DefaultLayout = React.createClass({
       </html>
     );
   }
-});
+}
 
 module.exports = DefaultLayout;
 ```
 
 `views/index.jsx`:
 ```js
-var DefaultLayout = require('./layouts/default');
+const React = require('react');
+const DefaultLayout = require('./layouts/default');
 
-var HelloMessage = React.createClass({
-  render: function() {
+class HelloMessage extends React.Component {
+  render() {
     return (
       <DefaultLayout title={this.props.title}>
         <div>Hello {this.props.name}</div>
       </DefaultLayout>
     );
   }
-});
+}
 
 module.exports = HelloMessage;
 ```

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@
 'use strict';
 
 var React = require('react');
+var ReactDOMServer = require('react-dom/server');
 var beautifyHTML = require('js-beautify').html;
 var nodeJSX = require('node-jsx');
 var assign = require('object-assign');
@@ -60,7 +61,7 @@ module.exports = function (engineOptions) {
                         callback(null, function (context, options, callback) {
                             var markup = doctype;
                             try {
-                                markup += React.renderToStaticMarkup(component(context));
+                                markup += ReactDOMServer.renderToString(component(context));
                             }
                             catch (e) {
                                 throw e;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hapijs-react-views",
-    "version": "0.7.3",
+    "version": "0.8.0",
     "description": "This is a Hapi view engine which renders React components on server. It renders static markup and *does not* support mounting those views on the client.",
     "keywords": [
         "hapi",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "author": "Ryan Wilson <syndicated.life@gmail.com> (http://syndicatedlife.com/)",
     "license": "BSD-3-Clause",
     "peerDependencies": {
-        "react": "0.12 - 0.13"
+        "react": "16.0",
+        "react-dom": "16.0"
     },
     "dependencies": {
         "js-beautify": "^1.5.4",


### PR DESCRIPTION
`React.renderToStaticMarkup()` has been superseded by `ReactDOMServer.renderToString()`. Added `react-dom` as a peer dependency and updated code to use it for string generation.

Also, React apparently does not support `createClass()` any longer so I have updated the README to use the newer `React.Component()` function.